### PR TITLE
lsl begins indexing at 0

### DIFF
--- a/LBA-v2.22.1-Slim.lsl
+++ b/LBA-v2.22.1-Slim.lsl
@@ -10,7 +10,7 @@ integer die = TRUE;     // Does this script kill the object -OR- sends a message
 
 updateHP()
 {
-    if(hp < 1)
+    if(hp <= 0)
     {
         if(buffer != []) llOwnerSay(llDumpList2String(buffer, " | "));
         llSleep(0.1);


### PR DESCRIPTION
This is a very very small compiler optimization pass that's more to do with consistency than anything else. The script probably compiles an inperceivably amount faster now. There is no functional different between this update and the previous one.